### PR TITLE
NEWSとコンサートの一覧ページの日付の表示を変更 #160

### DIFF
--- a/src/views/Concerts.vue
+++ b/src/views/Concerts.vue
@@ -4,7 +4,7 @@
 
     <div v-for="(lc, i) in latest" :key=i :index=i id="concertList"  v-bind:class="{ended: lc.isEnd}">
       <v-row>
-        <v-col cols=4 md=5 class="pl-8 pl-md-12" ><span>{{ lc.date.year }}年{{ ('0' + lc.date.month).slice(-2) }}月{{ ('0' + lc.date.day).slice(-2) }}日</span></v-col>
+        <v-col cols=4 md=5 class="pl-8 pl-md-12 d-flex flex-column justify-center"><span>{{ lc.date.year }}/{{ ('0' + lc.date.month).slice(-2) }}/{{ ('0' + lc.date.day).slice(-2) }}</span></v-col>
       
         <v-col cols=8 md=7 ><router-link :to="`/concerts/${lc.id}`"><span>{{ lc.title }}</span></router-link></v-col>
       </v-row>

--- a/src/views/News.vue
+++ b/src/views/News.vue
@@ -3,7 +3,7 @@
     <Title en="News" ja="お知らせ"></Title>
     <div v-for="(news, i) in newsList" id="newsList" :key=i :index=i>
       <v-row>
-        <v-col cols=4 md=4 class="pl-8 pl-md-12" >{{ getFormatDate(news) }} </v-col>
+        <v-col cols=4 md=4 class="pl-8 pl-md-12 d-flex flex-column justify-center" >{{ getFormatDate(news) }} </v-col>
         <v-col cols=8 md=8 ><router-link :to="`/news/${news.id}`">{{ news.title }}</router-link></v-col>
       </v-row>
       <v-divider></v-divider>
@@ -32,7 +32,7 @@ export default {
       const year = news.date.year;
       const month = ('0' + news.date.month).slice(-2);
       const day = ('0' + news.date.day).slice(-2);
-      return year+'年'+month+'月'+day+'日';
+      return year+'/'+month+'/'+day;
     }
   },
   created() {


### PR DESCRIPTION
#160 
日付をyyyy年mm月dd日からyyyy/mm/ddに変更
日付を上下中央ぞろえに変更
